### PR TITLE
Quick implementation of the standard implement/override actions

### DIFF
--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -344,7 +344,14 @@
         </action>
     </actions>
 
+
+
     <extensions defaultExtensionNs="com.intellij">
+
+        <codeInsight.overrideMethod language="Pascal" implementationClass="com.siberika.idea.pascal.ide.extensions.PascalOverrideMethodsHandler"/>
+        <codeInsight.implementMethod language="Pascal" implementationClass="com.siberika.idea.pascal.ide.extensions.PascalImplementMethodsHandler"/>
+
+
         <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
 
         <codeInsight.gotoSuper language="Pascal" implementationClass="com.siberika.idea.pascal.ide.actions.GotoSuper"/>

--- a/plugin/src/ide/extensions/PascalImplementMethodsHandler.java
+++ b/plugin/src/ide/extensions/PascalImplementMethodsHandler.java
@@ -1,0 +1,59 @@
+package com.siberika.idea.pascal.ide.extensions;
+
+import com.intellij.lang.ContextAwareActionHandler;
+import com.intellij.lang.LanguageCodeInsightActionHandler;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.siberika.idea.pascal.ide.actions.ActionImplement;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * User: LPUser
+ * Date: 03/07/2018
+ * Time: 16:35
+ */
+public class PascalImplementMethodsHandler implements ContextAwareActionHandler, LanguageCodeInsightActionHandler
+{
+  private ActionImplement getActionImplement()
+  {
+    AnAction action = ActionManager.getInstance().getAction("Pascal.OverrideMethod");
+    if (action == null || !(action instanceof ActionImplement))
+    {
+      return null;
+    }
+    return (ActionImplement)action;
+  }
+
+  @Override
+  public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file)
+  {
+    ActionImplement actionImplement = getActionImplement();
+    if (actionImplement == null)
+    {
+      return;
+    }
+
+    PsiElement elementAt = file.findElementAt(editor.getCaretModel().getOffset());
+    if (elementAt != null)
+    {
+      actionImplement.showOverrideDialog(elementAt, editor);
+    }
+  }
+
+  @Override
+  public boolean isAvailableForQuickList(@NotNull Editor editor, @NotNull PsiFile file, @NotNull DataContext dataContext)
+  {
+    return true;
+  }
+
+  @Override
+  public boolean isValidFor(Editor editor, PsiFile file)
+  {
+    return true;
+  }
+}

--- a/plugin/src/ide/extensions/PascalOverrideMethodsHandler.java
+++ b/plugin/src/ide/extensions/PascalOverrideMethodsHandler.java
@@ -1,0 +1,59 @@
+package com.siberika.idea.pascal.ide.extensions;
+
+import com.intellij.lang.ContextAwareActionHandler;
+import com.intellij.lang.LanguageCodeInsightActionHandler;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.siberika.idea.pascal.ide.actions.ActionImplement;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * User: LPUser
+ * Date: 03/07/2018
+ * Time: 16:35
+ */
+public class PascalOverrideMethodsHandler implements ContextAwareActionHandler, LanguageCodeInsightActionHandler
+{
+  private ActionImplement getActionImplement()
+  {
+    AnAction action = ActionManager.getInstance().getAction("Pascal.OverrideMethod");
+    if (action == null || !(action instanceof ActionImplement))
+    {
+      return null;
+    }
+    return (ActionImplement)action;
+  }
+
+  @Override
+  public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file)
+  {
+    ActionImplement actionImplement = getActionImplement();
+    if (actionImplement == null)
+    {
+      return;
+    }
+
+    PsiElement elementAt = file.findElementAt(editor.getCaretModel().getOffset());
+    if (elementAt != null)
+    {
+      actionImplement.showOverrideDialog(elementAt, editor);
+    }
+  }
+
+  @Override
+  public boolean isAvailableForQuickList(@NotNull Editor editor, @NotNull PsiFile file, @NotNull DataContext dataContext)
+  {
+    return true;
+  }
+
+  @Override
+  public boolean isValidFor(Editor editor, PsiFile file)
+  {
+    return true;
+  }
+}


### PR DESCRIPTION
Tried to make the minimum changes possible to quickly add support for standard "override" & "implement" actions, using the existing ActionImplement.

Note it's not the cleanest as clearly implement and override contain exactly the same code for now.

I plan on later changing things so that "implement" would present only currently abstract method (from an interface or abstract in parent).